### PR TITLE
Modify shell script to accept variable from the environment

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec /opt/chronograf/chronograf -bind=0.0.0.0:80 -influx=INFLUXDB_PROTO://INFLUXDB_HOST:INFLUXDB_PORT
+exec /opt/chronograf/chronograf -bind=0.0.0.0:80 -influx=$INFLUXDB_PROTO://$INFLUXDB_HOST:$INFLUXDB_PORT


### PR DESCRIPTION
The old version followed the convention of uppercase naming but did
not put a $ character in front of the environment variables so they
were never correctly read.
