### PR TITLE
Update to match v0.4 options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,8 @@ RUN apt-get update && apt-get install -y wget
 RUN wget https://s3.amazonaws.com/get.influxdb.org/chronograf/chronograf_${CHRONOGRAF_VERSION}_amd64.deb
 RUN dpkg -i chronograf_${CHRONOGRAF_VERSION}_amd64.deb && rm chronograf_${CHRONOGRAF_VERSION}_amd64.deb
 
-COPY run.sh /run.sh
-RUN chmod +x /run.sh
+# Allow Chronograf to accept connections from other hosts
+ENV CHRONOGRAF_BIND=0.0.0.0:10000
+EXPOSE 10000
 
-ENV INFLUXDB_PROTO=http
-ENV INFLUXDB_HOST=localhost
-ENV INFLUXDB_PORT=8086
-
-EXPOSE 80
-CMD [ "/run.sh" ]
+CMD [ "/opt/chronograf/chronograf" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM debian:jessie
 # Override with e.g. $ docker build --build-arg CHRONOGRAF_VERSION=1.2.3
 ARG CHRONOGRAF_VERSION=0.4.0
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 RUN apt-get update && apt-get install -y wget
 RUN wget https://s3.amazonaws.com/get.influxdb.org/chronograf/chronograf_${CHRONOGRAF_VERSION}_amd64.deb
 RUN dpkg -i chronograf_${CHRONOGRAF_VERSION}_amd64.deb && rm chronograf_${CHRONOGRAF_VERSION}_amd64.deb

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec /opt/chronograf/chronograf -bind=0.0.0.0:80 -influx=$INFLUXDB_PROTO://$INFLUXDB_HOST:$INFLUXDB_PORT


### PR DESCRIPTION
The previous options format doesn't work with the latest release, this does.
